### PR TITLE
Pull over content from Google doc

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,6 @@
 
 # Site settings
 title: States FAQ
-email: your-email@domain.com
 description: >
   Frequently asked questions from 18F's state child welfare and Medicaid partners
 baseurl: "" # the subpath of your site, e.g. /blog

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,7 +5,7 @@ layout: default
 
   <header class="post-header">
     <h1 class="post-title" itemprop="name headline">{{ page.title }}</h1>
-    <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
+    <p class="post-meta">{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
   </header>
 
   <div class="post-content" itemprop="articleBody">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@ layout: default
 categories:
   Agile Development: Agile
   Modular Procurement: Modular Procurement
+  Open source: Open Source
 ---
 
 <div class="home">

--- a/pages/agile-development.md
+++ b/pages/agile-development.md
@@ -1,0 +1,111 @@
+---
+layout: post
+title: Agile development processes
+category: Agile
+permalink: /agile-development/
+---
+
+
+
+### We have heard several risks to the waterfall approach. What are the risks to agile approach?
+
+How do we deal with so many vendors? What if they use different languages and we don’t have staff familiar with those.
+
+You would ensure that the vendors:
+
+Build to common standards that are determined and controlled by the state
+Deliver code with good test coverage
+Use current and popular languages, tools and frameworks
+
+### Let’s say we build a new system with 12 modules, how do we maintain that system? Do we keep all of those vendors on board through the life of the project?
+
+No. If the modules are open source and built with standard languages, libraries, and frameworks, other vendors can jump in to add features or make fixes as necessary. This frees the state from having to rely on any given vendor for anything as new vendors can swap in and out.
+
+With iterative and incremental goals of agile development, continuous integration and continuous deployment activities become de facto needs of systems.  As a result, comprehensive automation (testing and deployment) becomes baked in as part of the development process.  This automation helps reduce the reliance on institutional knowledge from vendors leading to the reduction of barriers to entry for other vendors to maintain the system.  Increasing competition amongst vendors and thus keeping costs down to the state.
+
+### What happens when something goes wrong and vendors all blame each other? How does the problem get fixed quickly and who pays for that?
+
+With every release, you would have deployed code that is tested in the field. You could have an acceptance period. The state would be responsible for problems discovered after this period. It would be treated as fresh development that can be contracted out to any developer. This is a fact of (software development) life that has to be accepted.
+
+### Who do we call when something goes wrong?
+
+One of the great strengths of agile development is that delivery is incremental, which spreads the risk across the entire development process rather than loading all of it at the very end. When things go wrong, they’re smaller problems that can be fixed more quickly and more easily.
+
+If you discover a bug in the software, you would hire a vendor to fix it. It doesn’t have to be the same vendor that originally produced the code. In fact, the bug could simply be added to the product backlog and the next vendor would pick it up.
+
+If a vendor isn’t producing to the level you expect, you can simply not hire them for any subsequent work. The amount of time and effort lost is limited to that one development period, possibly as short as a few weeks, rather than the entire life of the project.
+
+### Pitfalls of the Strangler pattern in legacy system replacement
+
+During the period when the legacy system is also operational, you have two systems - for the users, for maintenance
+
+You may stop investment after initial wins and prolong this aforementioned period, for too long (perhaps forever)
+
+### In waterfall approach [our contracting office] would approve the document, design, development, and testing. How in agile will the oversight of the vendor occur without such documentation. After release, what documentation will exist to assist with maintenance? What documents would the state rely on if expectations are not met and there is disagreement on what was previously agreed upon (yet no approved documents). What would be the impact of legal contract complications without such documentation?
+
+Common misconception with agile is that just enough documentation gets interpreted as no documentation.  That is not true, agile prescribes creating documentation that is of value; rather than blindly creating documents that are prescribed by different phases of the SDLC.
+
+Maintenance related docs (like deployment scripts/processes) fall under this umbrella.
+
+As far as “oversight docs” like a requirements doc (used to gauge if the vendor “delivered” the functionality).  Expectations are managed in agile by having incremental releases.  Working software (or lack thereof) is the measure that can be used to assess the performance of a vendor.  Further, using working software as opposed to requirements documents as the gauge of performance allows for flexibility of discovery after each increment to adjust required functionality to be delivered.  I.e. A good vendor is not just one that delivers software functionality, but can also easily adapt to changing needs.
+
+### How can the long term costs of Agile be compared to the locked in cost to Waterfall? How can a state estimate the full need for funding for the project? 
+
+The locked in cost in waterfall is a piece of fiction, built upon further layers of fiction:
+
+The requirements are well-known
+The requirements do not change
+Users are able to articulate their requirements well and the development team can implement these precisely without any loss of fidelity.
+
+The return of the state’s investment should be measured in working software, not phase documents / gates of waterfall.  I.e. A fantastic requirements document will NOT be of value to the state’s constituents; only actual functionality will.   Based on that premise, waterfall will only be able to measure its return at the end of the project after most (if not all the costs) have been incurred as that is when working software is delivered.  This is a huge risk.  Agile incremental deliveries allows the state to measure returns at earlier phases (and less incurred costs) thus reducing the overall risk to the state.
+
+Also, you should try to steer away from the conversation of “full funding” because no system is ever fully funded.  (Think O&M!).  Instead have the conversation on how agile can help manage investment risk better because you receive early indicators on whether or not the state is getting a return on the investment or not.
+
+How do we evaluate between someone who has a COTS solution vs building from scratch with Agile?
+
+How do all these modules really fit together?
+
+How do COTS products fit into this? How much modification is ok?
+
+### We found a commercial/off the shelf (COTS) tool that would mostly meet our needs, but we would need to modify it. How should we do that?
+
+Configuring a COTS product to meet your needs is not inherently a problem. 18F frequently sees modifications to the underlying code base, which we call customization, grow to the point that the system cannot handle any updates from the COTS provider, which poses security risks and a risk to the long term viability of the tool. If you can already spot the ways that the tool does not meet your needs, it’s worth asking if your process could be adapted to meet the way the software already manages it. 
+
+Maybe we can add another sentence (if Greg et al think it's accurate)
+Alternatively, if process changes aren't feasible, state's can explore
+requiring any COTS provider to offer a convenient to use plug-in or bridge
+API that would allow independently developed custom code to meet the
+state's unique business need without creating unique interdependencies that
+will impact the COTS solution.
+
+If the problem domain is core to your work and is where you would like to innovate rapidly, it will not make sense to choose COTS. On the other hand, if it is auxiliary to your work and you can adopt the process implemented by the COTS product, COTS would make sense.
+
+Who is the system integrator? The state? A vendor? How does this work?
+
+We don’t have the staff to be the systems integrator? What should we look for to get that done? 
+
+We’ve had systems integrators before and they were the prime vendor responsible for the entire project? So how is this different?
+
+Agile seems to require different skills of my staff, how do I know what skill we need in house and how do we get that training? Or can I hire a vendor to do that?
+
+Once we hire an agile vendor, how do we know they’re going to deliver what we want?
+Vendors that can do agile work will respond to the way you are working. We recommend having an empowered product owner - a single person 
+
+What about governance? And IV&V? How does that work with agile development?
+Isn’t this a lot more work for my staff? Is it really worth it?
+Our mainframe is 30 years old and i can’t risk doing anything to make it stop working b/c it’s the only thing we have that works.
+
+There are development patterns that would allow systems to gradually migrate away from a mainframe (or legacy system).  For example, the use of proxies to abstract out new code from legacy code. Mainframes are designed to be highly efficient in executing very specific functions; split those functions out one by one and replace them. Also ensuring that there are swift fallback/reversion processes in place hels
+
+One can use agile prioritization techniques (like WSJF) you can identify the order of migration.  This prioritization technique isn’t based on expected benefit alone.  It also takes into consideration risk, effort and timing.
+
+But the key to success is migrating piece by piece;  aiming to do a one big bang cut over to a new system is extremely risky.
+
+We have lots of big projects coming up, what’s the best way to get started doing an agile project?
+
+### What does a user centered design team actually do that’s different from how we’ve always done it?
+
+Would recommend we not assume that other orgs are not doing user centered design.  First understand how they are sussing out features and what pain points they are experiencing.  From there, map how user centered design can help.
+
+How do I have my users participate in feedback?
+methods.18f.gov

--- a/pages/common-questions.md
+++ b/pages/common-questions.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: Common questions from state partners
+category: Modular procurement
+permalink: /common-questions/
+---
+
+There are a number of questions and concerns we've heard expressed in many of our workshops and conversations. Here's how we answer a few of them:
+
+**How do we evaluate vendors if they don’t estimate costs up front and the deliverables aren’t fixed? How is this better than knowing upfront costs and all deliverables and timelines?**
+
+Vendors would still be submitting proposals with associated costs, deliverables, etc. The difference with modular procurement is that what they are proposing against is much smaller and more frequent.
+
+**The federal government has up to 60 days to approve our Advance Planning Documents and our RFPs for projects involving federal grants. Doing more small procurements just means more delay. How can that be improved?**
+
+18F is committed to working with our federal partners to reduce the burden on state agencies to get smaller contracts approved. The approval cycle is to ensure that states are mitigating risk—and one of the best ways to do that is with shorter, lower-cost contracts. 
+
+**Can I just buy off 18Fs Agile Blanket Purchase Agreement (BPA)?**
+
+18F’s Agile BPA is only available for use by 18F and its partner agencies. As 18F can directly support states by establishing an Intergovernmental Cooperative Agreement with them, then any state or local entity can avail themselves of the services offered on it.
+
+**Who will I call when something goes wrong after launch?**
+
+We work to ensure that an appropriate acquisition plan is in place, so that an open source solution will be maintained, just like closed source software.
+
+**How can we ensure accountability without having a single systems integrator?**
+
+Paradoxically, the idea that a single systems integrator provides ultimate accountability and maximum control isn’t supported by decades of large-scale IT projects that used this approach. In the same way that most manufacturing companies rely on multiple suppliers, companies that need digital products have expanded their procurement practices with multisourcing, to reduce the type of risk that comes from vendor lock-in with a single systems integrator.

--- a/pages/modular-procurement.md
+++ b/pages/modular-procurement.md
@@ -1,0 +1,57 @@
+---
+layout: post
+title: Managing modular procurements
+category: Modular procurement
+permalink: /modular-procurement/
+---
+
+Modular procurement does two things that make it easier to manage development: it segments risks and increases transparency. Segmenting risk means that what was a single, monolithic project is handled as smaller, discrete units. If one unit fails, that failure is isolated. Because each project is smaller, they are easier to comprehend and manage, making  problems and risks smaller so you can recognize and resolve them more easily. 
+
+In practice, most traditional contracts already have multiple companies responsible for different parts of the effort, but you may not see that complexity until something goes wrong. The majority of large scale government IT projects fail, so it’s nearly inevitable that something will go wrong under a traditional procurement process.
+
+The [Standish Group found](http://www.computerworld.com/article/2486426/healthcare-it/healthcare-gov-website--didn-t-have-a-chance-in-hell-.html) that:
+
+> Of 3,555 projects from 2003 to 2012 that had labor costs of at least $10 million, only 6.4% were successful. The Standish data showed that 52% of the large projects were "challenged," meaning they were over budget, behind schedule or didn't meet user expectations. The remaining 41.4% were failures — they were either abandoned or started anew from scratch.
+
+**Modular procurement doesn't necessarily mean more work for your procurement team.**
+
+You do need to do some work up-front to change your procurement processes to support modular procurement. Modular procurement can actually reduce the work required, such as by simplifying vendor selection and speeding up the process.
+
+**Shorter contracts will reduce the risk of factors beyond your control.**
+
+Planning work for a successful six-month contract is easier than planning a successful six-year contract.
+
+At its core, modular procurement supports iterative development. This means that you are continuously improving, rather than merely hoping for perfection at some point in the future. Building a Minimal Viable Product (MVP) and learning from it ultimately results in a better product than the traditional approach of trying to build a more complex ideal project all at once.
+
+**Modular procurement is based on the reality that you will discover new requirements during the development process.**
+
+In any complex system, needs change, evolve, or are discovered over time. Instead of ignoring these changing needs, or going through a painful contract amendment and renegotiation process, we embrace the concept that we will discover new requirements as we go.
+
+To help this process, we pair identifying requirements at a higher level (an “epic” in agile terminology) with an ongoing user research process. These epics describe the user need, not the solution. Through the user research process, these epics are turned into a set of increasingly-specific user stories. This is done continuously, so that user stories are ready for the development team no more than a month ahead of when the development team implements them. (For example, a user story might be: “As a caseworker, I want to see all my current cases and next steps so I know what I need to do next, and when I need to do it.” We wouldn't write: “The system shall display the next step next to each case in a grid on the main screen.”)
+
+There are three leading causes why IT projects fail: a lack of reliable input from users, incomplete requirements and specifications, and changes in the requirements and specifications. The Standish Group, an IT research firm, publishes an annual report on IT projects, in which they point out that these causes of failure are about the impossibility of “knowing” requirements up front. Using modular procurement practices means incremental, iterative development aligned with shorter term, lower dollar amount contracts.
+
+**There are ways to make sure code is consistent and compatible while using multiple vendors.**
+
+There are well-documented, standardized software development practices that can be standardized across vendors, and tools to enforce those. By adopting a “programming style” and an automated style checking tool (known as a “linter”), your vendors can ensure the code style is consistent. By adopting other automated quality-checking tools (examples include Code Climate and HoundCI), your vendors can avoid other poor code quality practices. Because the code is open source, vendors can see the code they have to integrate with. By having automated integration and unit tests, your vendors can identify and fix code that breaks or doesn’t integrate as soon as it’s written.
+
+**Onboarding vendors is more manageable when projects are modular.**
+
+One of the major burdens of onboarding is the time for a vendor to understand the entirety of a project. By reducing the size of each project and simplifying the specs, the time required to onboard vendors can be reduced substantially. This makes it manageable to onboard several vendors over the course of a complex project, and reduces the risk.
+
+**Pre-qualified agile vendor pools can help speed up modular procurement in the long run.**
+
+Agile vendor pools are groups of vendors that have been pre-qualified to work on modular procurements.
+
+During the selection process, the vendor pool is asked to provide proof of their abilities through working code, rather than extensive documentation. That process can include:
+
+* Developing a programming challenge for the vendor community (for example, the challenge for Mississippi’s agile vendor pool was to build a prototype of a website that lets parents or caseworkers search for child care providers in their vicinity).
+* Defining a short period of time (days, not weeks) to build a prototype. * Asking for a link to the working prototype as part of their proposal,as well as a link to the public source code.
+* Evaluating the proposals based on adherence to coding and design best practices, proof they followed an agile methodology, and evidence of their user research.
+* Selecting the best performing companies for your pool. We recommend starting with a smaller number of companies, perhaps 8 to 10. This is a manageable number, and with a defined on and off-ramp process, the size of the pool can be modified as the amount of work that can be managed increases.
+* Once your pool is created, you can write a “task order” (specific language varies from federal to state to local governments), or an RFP that only goes out to the vendors on the pool. Since they are all pre-qualified, you know they are all capable of doing the work, which lets you skip that stage of the evaluations for each subsequent RFP.
+
+**Modular procurements allow the end user to start seeing benefits even before the legacy system can be fully retired.**
+
+Old systems must be kept up until the new system is fully operational, no matter what approach is used. In a monolithic approach, the end user must wait many months or years to use the new system and see any benefit — and that’s assuming there are no problems with the rollout. In a modular approach, the end user could start seeing benefits in weeks. Depending on the architecture of the legacy system, parts of it may even be able to be decommissioned and turned off before the full new system is in place to save money.
+

--- a/pages/open-source.md
+++ b/pages/open-source.md
@@ -1,0 +1,39 @@
+---
+layout: post
+title: Open source software projects
+category: Open source
+permalink: /open-source/
+---
+
+18F has committed to working with open source software because developing in the open has real benefits, especially for the public sector. The [18F Open Source Policy](https://github.com/18F/open-source-policy/blob/master/policy.md) explains the benefits of open source and answers many common questions about security, licensing, distribution, and exceptions. Our policy is _itself_ open source, which means it can be adapted for state use.
+
+* For a primer on how to begin to work on open source software projects, our [getting started with 18F Micro-purchase](https://pages.18f.gov/micropurchase/docs/getting-started/) guide has extensive guidance and resources. It was written for potential clients of our micro-purchase platform (which allows federal agencies to purchase small amounts of open source code for integration into an existing software product), but much of the guidance applies to any open source project.
+* Our blog post on [Facts about publishing open source code in government](https://18f.gsa.gov/2016/08/08/facts-about-publishing-open-source-code-in-government/) dispels some common myths about open source software.
+
+**Using open source software makes it easier to secure our systems and helps mitigate risks.**
+
+It is our belief — generally accepted among a number of security researchers, government officials (including federal CIOs and CTOs) — that well-managed, well-written open source software can be just as secure as closed source software, if not more so.
+
+The [Department of Defense Memo on Open Source Software](http://dodcio.defense.gov/Open-Source-Software-FAQ/) has a great explanation of [why hiding source code does not automatically make source code more secure](http://dodcio.defense.gov/Open-Source-Software-FAQ/#Q:_Doesn.27t_hiding_source_code_automatically_make_software_more_secure.3F).
+
+Open source software allows defenders, researchers, and IT providers to follow best practices and work together to make the software as secure as possible.
+
+**Open source systems are maintained much like closed source systems, but with more options for community support.**
+
+Government open source systems — like closed source systems — are maintained by skilled software developers who ensure that applications, operating systems, middleware, and libraries are up-to-date and secure.
+
+In closed source systems, there are limited choices for continued development and support (often within one or several companies).
+
+We work to ensure that an open source solution can be adopted by a larger group in the open source community, to support its ongoing development with the help of a wider community.
+
+**When you employ open source software, you are responsible for ensuring it meets your needs — just like closed source software.**
+
+Open source software requires quality review and ongoing maintenance, just like closed source software. Without the appropriate expert review, the risk of unknowingly receiving buggy software is the same for both open and closed software.
+
+All software needs to be maintained and updated to continue to function, especially as technology, compliance requirements, and processes change.
+
+As with any government IT solution, closed- or open-source, the burden of ensuring the functionality, security, and operability of the solution ultimately rests with government. Open source software can provide more transparency about the health of government software, and expand options for maintainance. Working in the open can also make vendors more accountable to the software development community because their work is visible.
+
+**Open source software supports your team’s technical skill development.**
+
+If your internal team needs to develop the technical skills to evaluate, customize, and maintain modern software systems, open source solutions can provide opportunities for workforce development by ensuring access to code. This grounds technical training and talent acquisition in the actual products and processes that are used.


### PR DESCRIPTION
Working closely with @brittag, I've pulled content from the source file into markdown. Given the constraints of the jekyll setup, I created several new files in the `pages` directory to house this content.

**Background**

I picked this up from a [writing lab issue](https://github.com/18F/writing-lab/issues/205). While the FAQ format is a great way to gather content and stay focused on your reader's concerns, we generally [recommend against presenting web content in FAQ format](https://pages.18f.gov/content-guide/structure-the-content/#dont-use-faqs) because it can be very hard to navigate, maintain, and read.

Instead, we've shifted to a format that can help your readers find the concepts and assertions they need to advocate for better procurement. Each header should function as a bite-size version of what they need to know, with deeper reasoning below.

The agile section still needs the most work (more consolidation/review from a subject matter expert), and I would recommend adding a side navigation, both to narrow the line-length for ease of reading and to make it easier to move around. The [18F Guides Template](https://github.com/18F/guides-template) is a great example of a simple design that solves these problems. 
